### PR TITLE
CPO-RAM06-229  remove params validation

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/sap/SapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SapConfiguration.java
@@ -168,15 +168,6 @@ public class SapConfiguration extends AbstractConfiguration {
         if (client == null) {
             throw new ConfigurationException("client is empty");
         }
-        if(readOnlyParams.length > 0)
-        {
-        	for (String readOnlyParam : readOnlyParams) {
-				if (!Arrays.asList(SapConnector.READ_ONLY_PARAMETERS).contains(readOnlyParam)) {
-					throw new ConfigurationException("parameter" + readOnlyParam + "is invalid");
-					//TODO - validate over full list of valid params? 
-				}
-			}
-        }
 
         parseTableDefinitions();
 


### PR DESCRIPTION
Removing validation for params as it's not full list of these. As SAP library could be updated list would not be valid later on anyways. Leave it to connector users to specify correct params there. Connector will return error with "param is not supported+ name"  anyways with correct name there.