### PR TITLE
Connector option to hide indirect ACTIVITYGROUPS (ORG_FLAG not empty)

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/sap/SapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SapConfiguration.java
@@ -120,6 +120,11 @@ public class SapConfiguration extends AbstractConfiguration {
     private Boolean useNativeNames = false;
 
     /**
+     * if this is true every activitygroup which is assigned to a accounts will be hidden from the result object
+     */
+    private Boolean hideIndirectActivitygroups = false;
+
+    /**
      * definition of any tables in SAP to read his data, for example:
      * * AGR_DEFINE as ACTIVITYGROUP - AGR_DEFINE is table name in SAP, ACTIVITYGROUP is his alias in connector
      * * MANDT:3:IGNORE - MANDT is his first column with length 3 and in connector is ignored
@@ -300,6 +305,7 @@ public class SapConfiguration extends AbstractConfiguration {
                 ", tableKeys=" + tableKeys +
                 ", tableIgnores=" + tableIgnores +
                 ", tableAliases=" + tableAliases +
+                ", hideIndirectActivitygroups=" + hideIndirectActivitygroups +
                 '}';
     }
 
@@ -639,10 +645,19 @@ public class SapConfiguration extends AbstractConfiguration {
     public String[] getReadOnlyParams() {
         return readOnlyParams;
     }
-    
     public void setReadOnlyParams(String[] readOnlyParams) {
     	this.readOnlyParams = readOnlyParams;
     }
+
+    @ConfigurationProperty(order = 34, displayMessageKey = "sap.config.hideIndirectActivitygroups",
+            helpMessageKey = "sap.config.hideIndirectActivitygroups.help")
+    public Boolean getHideIndirectActivitygroups() {
+        return hideIndirectActivitygroups;
+    }
+    public void setHideIndirectActivitygroups(Boolean hideIndirectActivitygroups) {
+        this.hideIndirectActivitygroups = hideIndirectActivitygroups;
+    }
+
 
     private String getPlainPassword() {
         final StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/evolveum/polygon/connector/sap/SapConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SapConnector.java
@@ -902,8 +902,10 @@ public class SapConnector implements PoolableConnector, TestOp, SchemaOp, Search
         // tables and his id's
         for (String tableName : configuration.getTableParameterNames()) {
             Table table = new Table(function.getTableParameterList().getTable(tableName));
+            if(configuration.getHideIndirectActivitygroups() && ACTIVITYGROUPS.equals(tableName)){
+                table.getValues().removeIf(entry -> StringUtil.isNotBlank(entry.getByAttribute("ORG_FLAG")));
+            }
             builder.addAttribute(AttributeBuilder.build(tableName, table.getXmls()));
-
             if (TABLETYPE_PARAMETER_KEYS.containsKey(tableName)) {
                 String attribute = TABLETYPE_PARAMETER_KEYS.get(tableName);
                 builder.addAttribute(AttributeBuilder.build(tableName + SEPARATOR + TABLETYPE_PARAMETER_KEYS.get(tableName), table.getIds(attribute)));

--- a/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
@@ -81,3 +81,5 @@ sap.config.tracePath=JCo trace path
 sap.config.tracePath.help=location for trace files, sample: /tmp/saplogs  
 sap.config.read.only.params=Rewrite-able Read Only Parameters
 sap.config.read.only.params.help=This rewrites Read Only Parameters which are used to restrict transfer of certain entities, sample values are : "ISLOCKED", "LASTMODIFIED", "SNC", "ADMINDATA", "IDENTITY"  
+sap.config.hideIndirectActivitygroups=Hide indirect (ORG_FLAG not empty) ACTIVITYGROUPS
+sap.config.hideIndirectActivitygroups.help=This flag will hide indirect ACITIVITYGROUPS at accounts. The filtering will be done in the connector and not inside the SAP query. All ACITIVITYGROUPS where the "ORG_FLAG" field is not empty will not be shown in the shadow.


### PR DESCRIPTION
This change introduces a new configuration option to hide every indirect ACTIVITGROUP
(identified by the ORG_FLAG tag in the ri:ACTIVITYGROUPS field being not empty).
This was introduced because the indirect and complex SAP role hierarchies are not important
for the user administration in midpoint. Managing those is quiet complicated because the easiest
way to manage the association to activigroups is the ACTIVITYGROUPS.AGR_NAME field on the user.
To ignore indirect activitygroups inside midPoint you need complicated mappings which are difficult
to test. With this change its quite easy to hide them from midPoint.

The feature is disabled on default.

The actual filtering will be done in the connector and not in the SAP query.