### PR TITLE
Fix "TABLE_EMPTY" (MID-7753)

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/sap/SapConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SapConnector.java
@@ -649,6 +649,9 @@ public class SapConnector implements PoolableConnector, TestOp, SchemaOp, Search
                 } while (entries.nextRow());
             }
         } catch (JCoException e) {
+            //there is no other way of checking this
+            if("TABLE_EMPTY".equals(e.getKey()))
+                return;
             throw new ConnectorIOException(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
The BAPI function `RFC_GET_TABLE_ENTRIES` will propagate an error if the result ist empty.
This caused JCO to throw an exception. As far as i know there is no other way than catching it and
return an empty result if the exception key is "TABLE_EMPTY".