### PR TITLE
Configuration option baseAccountQuery to limit BAPI_USER_GETLIST scope

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/sap/SapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SapConfiguration.java
@@ -180,6 +180,11 @@ public class SapConfiguration extends AbstractConfiguration {
      */
 	private String baseAccountQuery = null;
 
+	/** 
+	 * Include GLOB_LOCK in account status evaluation.
+	 */
+	private boolean considerGlobalLock = false;
+
     @Override
     public void validate() {
         if (isBlank(host)) {
@@ -715,7 +720,7 @@ public class SapConfiguration extends AbstractConfiguration {
     }
 
 
-    @ConfigurationProperty(order = 36, displayMessageKey = "sap.config.baseAccountQuery",
+    @ConfigurationProperty(order = 37, displayMessageKey = "sap.config.baseAccountQuery",
             helpMessageKey = "sap.config.baseAccountQuery.help")
     public String getBaseAccountQuery() {
         return baseAccountQuery;
@@ -723,10 +728,18 @@ public class SapConfiguration extends AbstractConfiguration {
 
     public void setBaseAccountQuery(String baseAccountQuery) {
         this.baseAccountQuery = baseAccountQuery;
-    }
+	}
 
-    
-    
+	@ConfigurationProperty(order = 38, displayMessageKey = "sap.config.considerGlobalLock", 
+			helpMessageKey = "sap.config.considerGlobalLock.help")
+	public boolean getConsiderGlobalLock() {
+		return this.considerGlobalLock;
+	}
+
+	public void setConsiderGlobalLock(boolean considerGlobalLock) {
+		this.considerGlobalLock = considerGlobalLock;
+	}
+
     private String getPlainPassword() {
         final StringBuilder sb = new StringBuilder();
         if (password != null) {
@@ -813,4 +826,5 @@ public class SapConfiguration extends AbstractConfiguration {
     public Map<String, String> getTableAliases() {
         return tableAliases;
     }
+
 }

--- a/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
@@ -87,3 +87,5 @@ sap.config.nonFatalErrorCodes=Non-fatal error codes
 sap.config.nonFatalErrorCodes.help=Specify which SAP error codes are considered as non-fatal in account update response. Such errors are marked as schema errors rather than generic errors and typically do not halt the processing of entire focus. Examples: 025, 410.  
 sap.config.pwdChangeErrorIsFatal=Password change error fatal
 sap.config.pwdChangeErrorIsFatal.help=Specify how strictly should connector react to password change errors (e.g. user password is too short for SAP). Default is true - connector throws InvalidCredentialException errors that may be considered as fatal by IdM. When switched to false, password errors are returned as InvalidAttributeValueException that is more likely considered as non-blocking "soft" error.
+sap.config.baseAccountQuery=Base account list query
+sap.config.baseAccountQuery.help=Simple filter added to all account queries to limit the accounts read by BAPI_USER_GETLIST. Format is "option,parameter,value" (option means operator in sap language), commas are currently not escaped. "CP,USERNAME,PRE*" to limit all queries to all accounts with username prefix 'PRE'.

--- a/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
@@ -89,3 +89,5 @@ sap.config.pwdChangeErrorIsFatal=Password change error fatal
 sap.config.pwdChangeErrorIsFatal.help=Specify how strictly should connector react to password change errors (e.g. user password is too short for SAP). Default is true - connector throws InvalidCredentialException errors that may be considered as fatal by IdM. When switched to false, password errors are returned as InvalidAttributeValueException that is more likely considered as non-blocking "soft" error.
 sap.config.baseAccountQuery=Base account list query
 sap.config.baseAccountQuery.help=Simple filter added to all account queries to limit the accounts read by BAPI_USER_GETLIST. Format is "option,parameter,value" (option means operator in sap language), commas are currently not escaped. "CP,USERNAME,PRE*" to limit all queries to all accounts with username prefix 'PRE'.
+sap.config.considerGlobalLock=Evaluate local AND global lock for account status
+sap.config.considerGlobalLock.help=Consider account GLOB_LOCK value as well as LOCAL_LOCK when evaluating whether account is enabled/disabled (default is false as not considering it may be a feature and not a bug)


### PR DESCRIPTION
Simple filter added to all account queries to limit the accounts read by BAPI_USER_GETLIST. 

Format is "option,parameter,value" (option means operator in sap language). Commas in value are currently not supported. 

E.g. "CP,USERNAME,PRE*" limits USER_GETLIST to accounts with username prefix 'PRE' in addition to filter passed by client call.