### PR TITLE
Select configurable sub-tables for generic table entries

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/sap/SapConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SapConnector.java
@@ -28,12 +28,20 @@ import org.identityconnectors.framework.spi.Configuration;
 import org.identityconnectors.framework.spi.ConnectorClass;
 import org.identityconnectors.framework.spi.PoolableConnector;
 import org.identityconnectors.framework.spi.operations.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -145,6 +153,8 @@ public class SapConnector implements PoolableConnector, TestOp, SchemaOp, Search
     private Map<String, String> sapAttributesType = new HashMap<String, String>();
 
 	private SapFilter baseAccountQuery;
+
+    private Transformer xmlTransformer;
 
     @Override
     public Configuration getConfiguration() {
@@ -390,6 +400,17 @@ public class SapConnector implements PoolableConnector, TestOp, SchemaOp, Search
                 objClassBuilder.addAttributeInfo(attributeInfoBuilder.build());
             }
 
+            List<SubTableMetadata> subTables = configuration.getSubTablesMetadata().get(tableName);
+            if (subTables != null) {
+                for (SubTableMetadata subTable : subTables) {
+                    AttributeInfoBuilder attributeInfoBuilder = new AttributeInfoBuilder(subTable.getVirtualColumnName());
+                    attributeInfoBuilder.setCreateable(false);
+                    attributeInfoBuilder.setUpdateable(false);
+                    attributeInfoBuilder.setMultiValued(true);
+                    objClassBuilder.addAttributeInfo(attributeInfoBuilder.build());
+                }
+            }
+
             builder.defineObjectClass(objClassBuilder.build());
         }
     }
@@ -618,11 +639,17 @@ public class SapConnector implements PoolableConnector, TestOp, SchemaOp, Search
                     ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
                     List<String> keys = new LinkedList<String>();
 
+                    Map<String, String> rootValues = new LinkedHashMap<>();
+
                     for (Map.Entry<String, Integer> entry : configuration.getTableMetadatas().get(tableName).entrySet()) {
                         String column = entry.getKey();
                         Integer length = entry.getValue();
 
-                        String columnValue = value.substring(index, index + length).trim();
+                        int maxIndex = Math.min(index + length, value.length());
+                        String columnValue = value.substring(index, maxIndex).trim();
+
+                        rootValues.put(column, columnValue);
+
                         // ignore columns, what is selected as :IGNORE
                         if (!configuration.getTableIgnores().get(tableName).contains(column)) {
                             addAttr(builder, column, columnValue);
@@ -644,6 +671,22 @@ public class SapConnector implements PoolableConnector, TestOp, SchemaOp, Search
                     if (StringUtil.isEmpty(concatenatedKey.toString())) {
                         LOG.warn("ignoring empty key: " + concatenatedKey);
                         continue;
+                    }
+
+                    if (configuration.getSubTablesMetadata().containsKey(tableName)) {
+                        for (SubTableMetadata subTables : configuration.getSubTablesMetadata().get(tableName)) {
+                            try {
+                                builder.addAttribute(subTables.getVirtualColumnName(),
+                                                     executeTableSubQuery(concatenatedKey.toString(), subTables, rootValues));
+                            } catch (JCoException e) {
+                                if ("TABLE_EMPTY".equals(e.getKey())) {
+                                    // Workaround to handle empty results
+                                    builder.addAttribute(subTables.getTableName(), new ArrayList<>());
+                                } else {
+                                    throw new ConnectorIOException("Error during sub-table query for " + subTables.getTableName() + ": " + e.getMessage(), e);
+                                }
+                            }
+                        }
                     }
 
                     builder.setUid(concatenatedKey.toString());
@@ -677,6 +720,99 @@ public class SapConnector implements PoolableConnector, TestOp, SchemaOp, Search
                 }
             }
         }
+    }
+
+    private List<String> executeTableSubQuery(String queryKey, SubTableMetadata metadata, Map<String, String> rootValues) throws JCoException {
+        JCoFunction function = destination.getRepository().getFunction("RFC_GET_TABLE_ENTRIES");
+        if (function == null) {
+            throw new RuntimeException("RFC_GET_TABLE_ENTRIES not found in SAP.");
+        }
+
+        // this search does not use EQUALS operator but rather something similar to startsWith, also see support 9749
+        function.getImportParameterList().setValue("TABLE_NAME", metadata.getTableName());
+        function.getImportParameterList().setValue("GEN_KEY", queryKey);
+        LOG.ok("sub-query by key: " + queryKey + " on table: " + metadata.getTableName());
+
+        function.execute(destination);
+
+        JCoTable entries = function.getTableParameterList().getTable("ENTRIES");
+        LOG.info("Entries: " + function.getExportParameterList().getValue("NUMBER_OF_ENTRIES"));
+
+        int numRows = entries.getNumRows();
+        entries.firstRow();
+        List<String> values = new ArrayList<>();
+
+        if (numRows > 0) {
+            do {
+                String value = entries.getString("WA");
+
+                Map<String, String> columnValues = new LinkedHashMap<>();
+                boolean matches = true;
+
+                for (TableColumnDefinition column : metadata.getColumns()) {
+                    int minIndex = Math.min(column.getOffset(), value.length());
+                    int maxIndex = Math.min(column.getOffset() + column.getLength(), value.length());
+                    String columnValue = value.substring(minIndex, maxIndex).trim();
+
+                    if (column.getFilterConstant() != null && !column.getFilterConstant().equals(columnValue)) {
+                        matches = false;
+                    }
+                    if (column.getMode() == TableColumnDefinition.Mode.OUTPUT) {
+                        columnValues.put(column.getColumnName(), columnValue);
+                    } else if(column.getMode() == TableColumnDefinition.Mode.MATCH) {
+                        if (!rootValues.getOrDefault(column.getColumnName(), "").equals(columnValue)) {
+                            matches = false;
+                        }
+                    }
+                }
+
+                if (!matches) {
+                    // There might be rows, that should not be included.
+                    // The reason for possibility is the query method (similar to startsWith see support 9749).
+                    // If one object has a key that is the prefix of another object's key, both results would be included.
+                    // Example:
+                    //   Role 1: ROLE_DEVELOPER
+                    //   Role 2: ROLE_DEVELOPER_READ
+                    // Searching in any table for "ROLE_DEVELOPER" will also return all rows that belong to "ROLE_DEVELOPER_READ"
+                    continue;
+                }
+
+                if (metadata.getFormat() == SubTableMetadata.Format.XML) {
+                    try (StringWriter writer = new StringWriter()) {
+                        if (xmlTransformer == null) {
+                            xmlTransformer = TransformerFactory.newInstance().newTransformer();
+                        }
+
+                        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+                        Element root = document.createElement("item");
+                        document.appendChild(root);
+
+                        for (Map.Entry<String, String> entry : columnValues.entrySet()) {
+                            Element item = document.createElement(entry.getKey());
+                            item.appendChild(document.createTextNode(entry.getValue()));
+                            root.appendChild(item);
+                        }
+                        xmlTransformer.transform(new DOMSource(document), new StreamResult(writer));
+                        values.add(writer.toString());
+                    } catch (TransformerException | ParserConfigurationException | IOException e) {
+                        throw new ConnectorIOException("Could not format row as XML: " + e.getMessage(), e);
+                    }
+
+                } else if (metadata.getFormat() == SubTableMetadata.Format.TSV) {
+                    StringBuilder row = new StringBuilder();
+                    for (Map.Entry<String, String> entry : columnValues.entrySet()) {
+                        if (!row.isEmpty()) {
+                            row.append("\t");
+                        }
+                        row.append(entry.getValue());
+                    }
+                    values.add(row.toString());
+                }
+
+            } while (entries.nextRow());
+        }
+
+        return values;
     }
 
     private void executeAccountQuery(SapFilter query, ResultsHandler handler, OperationOptions options) {

--- a/src/main/java/com/evolveum/polygon/connector/sap/SapFilter.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SapFilter.java
@@ -16,6 +16,7 @@
 package com.evolveum.polygon.connector.sap;
 
 import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.framework.common.objects.filter.Filter;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -86,6 +87,8 @@ public class SapFilter {
      */
     private int arity;
 
+    private Filter inMemoryFilter;
+
     public SapFilter(String sapOperator, String attribute, String value) {
         this.setOption(sapOperator);
 
@@ -104,6 +107,10 @@ public class SapFilter {
 
     public SapFilter(String basicByNameEquals) {
         this.basicByNameEquals = basicByNameEquals;
+    }
+
+    public SapFilter(Filter inMemoryFilter) {
+        this.inMemoryFilter = inMemoryFilter;
     }
 
     public SapFilter(String logicalOperation, SapFilter leftExpression) {
@@ -229,6 +236,10 @@ public class SapFilter {
 
     public void setArity(int arity) {
         this.arity = arity;
+    }
+
+    public Filter getInMemoryFilter() {
+        return inMemoryFilter;
     }
 
     @Override

--- a/src/main/java/com/evolveum/polygon/connector/sap/SubTableMetadata.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/SubTableMetadata.java
@@ -1,0 +1,127 @@
+package com.evolveum.polygon.connector.sap;
+
+import org.identityconnectors.framework.common.exceptions.ConfigurationException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SubTableMetadata {
+    private String rootTableName;
+    private String tableName;
+    private String virtualColumnName;
+    private Format format = SubTableMetadata.Format.XML;
+    private final List<TableColumnDefinition> columns = new ArrayList<>();
+
+    private static final Pattern PATTERN_FOR = Pattern.compile(" for ([^ ]+)");
+    private static final Pattern PATTERN_FORMAT = Pattern.compile(" format ([^ ]+)");
+    private static final Pattern PATTERN_AS = Pattern.compile(" as ([^ ]+)");
+    private static final Pattern PATTERN_NAME = Pattern.compile("^([^ ]+)");
+
+    public enum Format {
+        /**
+         * XML format with each column as separate XML tag.
+         */
+        XML,
+
+        /**
+         * All columns are concatenated with TAB as separator.
+         * TAB characters are usually not used by SAP, so the values don't need escaping.
+         */
+        TSV
+    }
+
+    public String getRootTableName() {
+        return rootTableName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getVirtualColumnName() {
+        return virtualColumnName;
+    }
+
+    public List<TableColumnDefinition> getColumns() {
+        return columns;
+    }
+
+    public Format getFormat() {
+        return format;
+    }
+
+    private int getTableWidth() {
+        int width = 0;
+        for (TableColumnDefinition c : columns) {
+            width += c.getLength();
+        }
+        return width;
+    }
+
+    public static SubTableMetadata parseConfig(String config) {
+        SubTableMetadata metadata = new SubTableMetadata();
+
+        String[] definitionParts = config.split("=");
+        if (definitionParts.length != 2) {
+            throw new ConfigurationException(
+                    "Please use correct sub-table definition, for example: 'AGR_TEXTS for AGR_DEFINE format TSV as ShortDescription=MANDT:3:IGNORE,AGR_NAME:30:MATCH,SPRAS:1(\"E\"):IGNORE,LINE:5(\"00000\"):IGNORE,TEXT:80', got: " +
+                    config);
+        }
+
+        metadata.parseTableDefinition(definitionParts[0]);
+
+        String[] allColumnsDef = definitionParts[1].split(",");
+        if (allColumnsDef.length == 0) {
+            throw new ConfigurationException(
+                    "Please specify at least one column definition for the sub-table after the '=' character, for example: '...=AGR_NAME:30', got: " +
+                    config);
+        }
+
+        for (String columnDefinition : allColumnsDef) {
+            metadata.columns.add(TableColumnDefinition.parseConfig(metadata.getTableWidth(), columnDefinition));
+        }
+
+        return metadata;
+    }
+
+    private void parseTableDefinition(String definitionPart) {
+        Matcher nameMatcher = PATTERN_NAME.matcher(definitionPart);
+        if (nameMatcher.find()) {
+            tableName = nameMatcher.group(1);
+        } else {
+            throw new ConfigurationException(
+                    "Please specify a sub-table name before the '=' character (example: 'AGR_TEXTS for ARG_DEFINE=...'), got: " +
+                    definitionPart);
+        }
+
+        Matcher rootNameMatcher = PATTERN_FOR.matcher(definitionPart);
+        if (rootNameMatcher.find()) {
+            rootTableName = rootNameMatcher.group(1);
+        } else {
+            throw new ConfigurationException(
+                    "Please specify a root table name, on which this sub-table depends (example: 'AGR_TEXTS for ARG_DEFINE=...'), got: " +
+                    definitionPart);
+        }
+
+        Matcher typeMatcher = PATTERN_FORMAT.matcher(definitionPart);
+        if (typeMatcher.find()) {
+            try {
+                format = Format.valueOf(typeMatcher.group(1));
+            } catch (IllegalArgumentException e) {
+                throw new ConfigurationException(
+                        "Please use one of these formats: " + Arrays.toString(Format.values()) + ", got: " +
+                        typeMatcher.group(1), e);
+            }
+        }
+
+        Matcher aliasMatcher = PATTERN_AS.matcher(definitionPart);
+        if (aliasMatcher.find()) {
+            virtualColumnName = aliasMatcher.group(1);
+        } else {
+            virtualColumnName = tableName;
+        }
+    }
+}

--- a/src/main/java/com/evolveum/polygon/connector/sap/TableColumnDefinition.java
+++ b/src/main/java/com/evolveum/polygon/connector/sap/TableColumnDefinition.java
@@ -1,0 +1,102 @@
+package com.evolveum.polygon.connector.sap;
+
+import org.identityconnectors.framework.common.exceptions.ConfigurationException;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TableColumnDefinition {
+    private String columnName;
+    private int offset;
+    private int length;
+    private Mode mode = Mode.OUTPUT;
+    private String filterConstant;
+
+    public enum Mode {
+        /**
+         * Don't include this column in the result.
+         */
+        IGNORE,
+
+        /**
+         * Don't include this column in the result.
+         * The value of this column has to be equal to the same column in the root table.
+         */
+        MATCH,
+
+        /**
+         * Include this column in the result. This is the default setting if nothing is specified.
+         */
+        OUTPUT
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public String getFilterConstant() {
+        return filterConstant;
+    }
+
+    private static final Pattern PATTERN_FILTER_CONST = Pattern.compile("^(\\d+)\\(\"(.*)\"\\)$");
+
+    private static final String FORMAT = "<columnName>:<size>[(\"<filterValue>\")][:<syncMode>]";
+
+    public static TableColumnDefinition parseConfig(int currentOffset, String config) {
+        String[] allParts = config.split(":");
+
+        TableColumnDefinition res = new TableColumnDefinition();
+        res.offset = currentOffset;
+
+        if (allParts.length < 2 || allParts.length > 3) {
+            throw new ConfigurationException("Please specify a column name in the requires format " + FORMAT +
+                                             " (example: 'MANDT:3:IGNORE'), got: " + config);
+        }
+
+        res.columnName = allParts[0];
+
+        Matcher matcher = PATTERN_FILTER_CONST.matcher(allParts[1]);
+        if (matcher.find()) {
+            try {
+                res.length = Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException e) {
+                throw new ConfigurationException("Please specify a column width as integer, got: '" + matcher.group(1) +
+                                                 "' in column definition: '" + config + "'");
+            }
+            res.filterConstant = matcher.group(2);
+        } else {
+            try {
+                res.length = Integer.parseInt(allParts[1]);
+            } catch (NumberFormatException e) {
+                throw new ConfigurationException(
+                        "Please specify a column width as integer, got: '" + allParts[1] + "' in column definition: '" +
+                        config + "'");
+            }
+        }
+
+        if (allParts.length > 2) {
+            try {
+                res.mode = Mode.valueOf(allParts[2]);
+            } catch (IllegalArgumentException e) {
+                throw new ConfigurationException(
+                        "Please use one of these column modes: " + Arrays.toString(SubTableMetadata.Format.values()) +
+                        ", got: " + allParts[2], e);
+            }
+        }
+
+        return res;
+    }
+}

--- a/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/sap/Messages.properties
@@ -49,6 +49,8 @@ sap.config.tables=Table definitions
 sap.config.tables.help=Name and structure of SAP table to read, for example 'AGR_DEFINE as ACTIVITYGROUP=MANDT:3:IGNORE,AGR_NAME:30:KEY,PARENT_AGR:30' return first for columns from roles (activity groups), UID and Name contains MANDT:ARG_NAME as KEYs
 sap.config.tableParameterNames=Table parameter names
 sap.config.tableParameterNames.help=Parameter names of Type='Tables' what you need to parse and have it in account schema, defaults are: PROFILES, ACTIVITYGROUPS, GROUPS, see http://www.sapdatasheet.org/abap/func/BAPI_USER_GET_DETAIL.html
+sap.config.subTables=Sub-Table definitions
+sap.config.subTables.help=Name and structure of additional SAP tables, that should be queried for each returned object, for example 'AGR_TEXTS for AGR_DEFINE format TSV as ShortDescription=MANDT:3:IGNORE,AGR_NAME:30:MATCH,SPRAS:1("E"):IGNORE,LINE:5("00000"):IGNORE,TEXT:80' selects the line '00000' of the language 'E' (english) from the AGR_TEXTS and puts the TEXT column into the ConnId attribute 'ShortDescription'. Another supported format is XML.
 sap.config.changePasswordAtNextLogon=Change password at next login
 sap.config.changePasswordAtNextLogon.help=If true, user after next SAP GUI logon must change his password (default is false)
 sap.config.alsoReadLoginInfo=Read login info


### PR DESCRIPTION
- Added config to specify additional tables to fetch for each query result
- Added output formats for sub-table result: XML and TSV (tab-separated values)
- Added filter options for sub-table results to only select specific values
- Added example to query the short description of activity groups
- Added example to query single roles that are part of a composite role
- Added example to query SAP flags for activity groups (these include a flag for the composite/single role distinction)